### PR TITLE
add HTML5 progress bar

### DIFF
--- a/static/js/foundation.js
+++ b/static/js/foundation.js
@@ -51,6 +51,7 @@
                 var $current_label = $container.find('.page_break_current');
                 var $total_label   = $container.find('.page_break_total');
                 var $pages = $container.siblings('.page_break');
+                var $progress_field   = $container.find('#progress');
 
                 var current_page  = 0;
                 var $current_page = $pages.eq(current_page);
@@ -71,6 +72,7 @@
                     $previous_link[current_page == 0 ? 'hide' : 'show']();
                     $next_button[current_page == total_pages - 1 ? 'hide' : 'show']();
                     $submit_button[current_page == total_pages - 1 ? 'show' : 'hide']();
+                    $progress_field.val((current_page+1) / total_pages) ;
                 }
 
                 $previous_link.on('click', function(e) {

--- a/views/foundation.view.php
+++ b/views/foundation.view.php
@@ -246,7 +246,7 @@ if ($has_page_break) {
                 )).'
             </div>',
         '{pagination}' => '
-                <div class="columns four">'.
+                <div class="columns four"> <progress id="progress"></progress> '.
                     strtr(__('{{current}} out of {{total}}'), array(
                         '{{current}}' => '<span class="page_break_current">1</span>',
                         '{{total}}' => '<span class="page_break_total">1</span>',


### PR DESCRIPTION
When form has a page_break(s) , showing a pregress bar is more user friendly.
I assume your browser supports HTML5. 

![form1](https://f.cloud.github.com/assets/531277/253367/f89179d6-8bce-11e2-8a0e-5ba63b3980ad.png)
![form2](https://f.cloud.github.com/assets/531277/253368/fcf64a42-8bce-11e2-89b6-88b8cb601a48.png)

Maybe here is not the best place to put on <progress> tag.
