### PR TITLE
Bugfix: delete attached files

### DIFF
--- a/classes/model/answer.model.php
+++ b/classes/model/answer.model.php
@@ -95,9 +95,9 @@ class Model_Answer extends \Nos\Orm\Model
             $files = \File::read_dir(APPPATH.'data'.DS.'files'.DS.'apps'.DS.'noviusos_form'.DS.$this->_form_id_for_delete, 1, array('^'.$this->_answer_id_for_delete.'_'));
             foreach ($files as $dir => $file) {
                 if (is_int($dir)) {
-                    \File::delete(APPPATH.'data'.DS.'files'.DS.'apps/noviusos_form'.DS.$file);
+                    \File::delete(APPPATH.'data'.DS.'files'.DS.'apps'.DS.'noviusos_form'.DS.$this->_form_id_for_delete.DS .$file);
                 } else {
-                    \File::delete_dir(APPPATH.'data'.DS.'files'.DS.'apps/noviusos_form'.DS.$dir);
+                    \File::delete_dir(APPPATH.'data'.DS.'files'.DS.'apps'.DS.'noviusos_form'.DS.$this->_form_id_for_delete.DS.$dir);
                 }
             }
         }


### PR DESCRIPTION
I'm not sure what the first case ("\File::delete...") is for ($dir shouldn't be always a directory?), so I wasn't able to test it.
