### PR TITLE
Increasing maximum number of form fields

### DIFF
--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -164,7 +164,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = & $fields_view_params;
+        $fields_view_params['view_params'] = &$fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
@@ -220,7 +220,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = & $fields_view_params;
+        $fields_view_params['view_params'] = &$fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
@@ -269,8 +269,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                     }
                     $field = $this->item->fields[$field_id];
                     if (!in_array($field->field_type, array('text', 'textarea', 'select', 'email', 'number', 'date',
-                        'checkbox', 'radio', 'hidden', 'variable', 'file'))
-                    ) {
+                        'checkbox', 'radio', 'hidden', 'variable', 'file'))) {
                         continue;
                     }
 

--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -163,14 +163,14 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = &$fields_view_params;
+        $fields_view_params['view_params'] = & $fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
         foreach ($this->config['fields_config'] as $name => $field_config) {
             $replaces[$name] = "field[{$item->field_id}][$name]";
         }
-        $return = (string)\View::forge('noviusos_form::admin/layout', $fields_view_params, false)->render() . $fieldset->build_append();
+        $return = (string) \View::forge('noviusos_form::admin/layout', $fields_view_params, false)->render() . $fieldset->build_append();
 
         return strtr($return, $replaces);
     }
@@ -194,7 +194,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         $item->save();
 
         \Response::json(array(
-            'fields' => (string)$this->render_page_break($item),
+            'fields' => (string) $this->render_page_break($item),
             'layout' => $item->field_id . '=4',
         ));
     }
@@ -219,14 +219,14 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = &$fields_view_params;
+        $fields_view_params['view_params'] = & $fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
         foreach ($this->config['fields_config'] as $name => $field_config) {
             $replaces[$name] = "field[{$item->field_id}][$name]";
         }
-        $return = (string)\View::forge('noviusos_form::admin/page_break', $fields_view_params, false);
+        $return = (string) \View::forge('noviusos_form::admin/page_break', $fields_view_params, false);
 
         return strtr($return, $replaces);
     }
@@ -268,7 +268,8 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                     }
                     $field = $this->item->fields[$field_id];
                     if (!in_array($field->field_type, array('text', 'textarea', 'select', 'email', 'number', 'date',
-                        'checkbox', 'radio', 'hidden', 'variable', 'file'))) {
+                        'checkbox', 'radio', 'hidden', 'variable', 'file'))
+                    ) {
                         continue;
                     }
 

--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -44,6 +44,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             }
         }
 
+        // The field data is serialized in json (cf. Pull Request #15)
         $fields_post = \Input::post('fields', null);
         $fields_data = array();
         if ($fields_post !== null) {

--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -303,11 +303,11 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
 
             // Send HTTP headers for inform the browser that it will receive a CSV file
             \Response::forge(\Format::forge($csv)->to_csv()."\n", 200, array(
-                    'Content-Type' => 'application/csv',
-                    'Content-Disposition' => 'attachment; '.
-                        'filename='.\Nos\Orm_Behaviour_Virtualname::friendly_slug($this->item->form_name).'.csv;',
-                    'Content-Transfer-Encoding' => 'binary',
-                ))->send(true);
+                'Content-Type' => 'application/csv',
+                'Content-Disposition' => 'attachment; '.
+                    'filename='.\Nos\Orm_Behaviour_Virtualname::friendly_slug($this->item->form_name).'.csv;',
+                'Content-Transfer-Encoding' => 'binary',
+            ))->send(true);
 
             $offset = 0;
             $limit = 500;

--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -44,12 +44,17 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             }
         }
 
-        $fields_data = \Input::post('field', array());
+        $fields_post = \Input::post('fields', null);
+        $fields_data = array();
+        if ($fields_post !== null) {
+            $fields_data = json_decode($fields_post, true);
+        }
 
         foreach ($fields_data as $index => $field) {
+
             // The default_value from POST is a comma-separated string of the indexes
             // We want to store textual values (separated by \n for the multiple values of checkboxes)
-            if (in_array($field['field_type'], array('checkbox', 'select', 'radio'))) {
+            if (isset($field['field_type']) && in_array($field['field_type'], array('checkbox', 'select', 'radio'))) {
                 $choices = explode("\n", $field['field_choices']);
                 $default_value = explode(',', $field['field_default_value']);
                 $default_value = array_combine($default_value, $default_value);
@@ -150,7 +155,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         $auto_id = uniqid('auto_id_');
         foreach ($fieldset->field() as $field) {
             if ($field->get_attribute('id') == '') {
-                $field->set_attribute('id', $auto_id.$auto_id_increment++);
+                $field->set_attribute('id', $auto_id . $auto_id_increment++);
             }
         }
 
@@ -158,14 +163,14 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = &$fields_view_params;
+        $fields_view_params['view_params'] = & $fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
         foreach ($this->config['fields_config'] as $name => $field_config) {
             $replaces[$name] = "field[{$item->field_id}][$name]";
         }
-        $return = (string) \View::forge('noviusos_form::admin/layout', $fields_view_params, false)->render().$fieldset->build_append();
+        $return = (string)\View::forge('noviusos_form::admin/layout', $fields_view_params, false)->render() . $fieldset->build_append();
 
         return strtr($return, $replaces);
     }
@@ -189,8 +194,8 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         $item->save();
 
         \Response::json(array(
-            'fields' => (string) $this->render_page_break($item),
-            'layout' => $item->field_id.'=4',
+            'fields' => (string)$this->render_page_break($item),
+            'layout' => $item->field_id . '=4',
         ));
     }
 
@@ -206,7 +211,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         $auto_id = uniqid('auto_id_');
         foreach ($fieldset->field() as $field) {
             if ($field->get_attribute('id') == '') {
-                $field->set_attribute('id', $auto_id.$auto_id_increment++);
+                $field->set_attribute('id', $auto_id . $auto_id_increment++);
             }
         }
 
@@ -214,14 +219,14 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = &$fields_view_params;
+        $fields_view_params['view_params'] = & $fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
         foreach ($this->config['fields_config'] as $name => $field_config) {
             $replaces[$name] = "field[{$item->field_id}][$name]";
         }
-        $return = (string) \View::forge('noviusos_form::admin/page_break', $fields_view_params, false);
+        $return = (string)\View::forge('noviusos_form::admin/page_break', $fields_view_params, false);
 
         return strtr($return, $replaces);
     }
@@ -263,7 +268,8 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                     }
                     $field = $this->item->fields[$field_id];
                     if (!in_array($field->field_type, array('text', 'textarea', 'select', 'email', 'number', 'date',
-                        'checkbox', 'radio', 'hidden', 'variable', 'file'))) {
+                        'checkbox', 'radio', 'hidden', 'variable', 'file'))
+                    ) {
                         continue;
                     }
 
@@ -296,12 +302,12 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             gc_enable();
 
             // Send HTTP headers for inform the browser that it will receive a CSV file
-            \Response::forge(\Format::forge($csv)->to_csv()."\n", 200, array(
-                'Content-Type' => 'application/csv',
-                'Content-Disposition' => 'attachment; '.
-                    'filename='.\Nos\Orm_Behaviour_Virtualname::friendly_slug($this->item->form_name).'.csv;',
-                'Content-Transfer-Encoding' => 'binary',
-            ))->send(true);
+            \Response::forge(\Format::forge($csv)->to_csv() . "\n", 200, array(
+                    'Content-Type' => 'application/csv',
+                    'Content-Disposition' => 'attachment; ' .
+                        'filename=' . \Nos\Orm_Behaviour_Virtualname::friendly_slug($this->item->form_name) . '.csv;',
+                    'Content-Transfer-Encoding' => 'binary',
+                ))->send(true);
 
             $offset = 0;
             $limit = 500;
@@ -343,7 +349,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                     }
                     $csv[] = $csv_row;
                 }
-                \Response::forge(\Format::forge($csv)->to_csv()."\n")->send();
+                \Response::forge(\Format::forge($csv)->to_csv() . "\n")->send();
 
                 if (count($answers) < $limit) {
                     break;

--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -163,7 +163,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = & $fields_view_params;
+        $fields_view_params['view_params'] = &$fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
@@ -219,7 +219,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             'layout' => $this->config['fields_layout'],
             'fieldset' => $fieldset,
         );
-        $fields_view_params['view_params'] = & $fields_view_params;
+        $fields_view_params['view_params'] = &$fields_view_params;
 
         // Replace name="field[field_type][]" "with field[field_type][12345]" <- add field_ID here
         $replaces = array();
@@ -268,8 +268,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                     }
                     $field = $this->item->fields[$field_id];
                     if (!in_array($field->field_type, array('text', 'textarea', 'select', 'email', 'number', 'date',
-                        'checkbox', 'radio', 'hidden', 'variable', 'file'))
-                    ) {
+                        'checkbox', 'radio', 'hidden', 'variable', 'file'))) {
                         continue;
                     }
 

--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -38,7 +38,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                 continue;
             }
             if (filter_var(trim($email), FILTER_VALIDATE_EMAIL)) {
-                $item->form_submit_email .= $email . "\n";
+                $item->form_submit_email .= $email."\n";
             } else {
                 throw new \Exception('An email which receive answers is not a valid.');
             }
@@ -155,7 +155,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         $auto_id = uniqid('auto_id_');
         foreach ($fieldset->field() as $field) {
             if ($field->get_attribute('id') == '') {
-                $field->set_attribute('id', $auto_id . $auto_id_increment++);
+                $field->set_attribute('id', $auto_id.$auto_id_increment++);
             }
         }
 
@@ -170,7 +170,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         foreach ($this->config['fields_config'] as $name => $field_config) {
             $replaces[$name] = "field[{$item->field_id}][$name]";
         }
-        $return = (string) \View::forge('noviusos_form::admin/layout', $fields_view_params, false)->render() . $fieldset->build_append();
+        $return = (string) \View::forge('noviusos_form::admin/layout', $fields_view_params, false)->render().$fieldset->build_append();
 
         return strtr($return, $replaces);
     }
@@ -195,7 +195,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
 
         \Response::json(array(
             'fields' => (string) $this->render_page_break($item),
-            'layout' => $item->field_id . '=4',
+            'layout' => $item->field_id.'=4',
         ));
     }
 
@@ -211,7 +211,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
         $auto_id = uniqid('auto_id_');
         foreach ($fieldset->field() as $field) {
             if ($field->get_attribute('id') == '') {
-                $field->set_attribute('id', $auto_id . $auto_id_increment++);
+                $field->set_attribute('id', $auto_id.$auto_id_increment++);
             }
         }
 
@@ -302,10 +302,10 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
             gc_enable();
 
             // Send HTTP headers for inform the browser that it will receive a CSV file
-            \Response::forge(\Format::forge($csv)->to_csv() . "\n", 200, array(
+            \Response::forge(\Format::forge($csv)->to_csv()."\n", 200, array(
                     'Content-Type' => 'application/csv',
-                    'Content-Disposition' => 'attachment; ' .
-                        'filename=' . \Nos\Orm_Behaviour_Virtualname::friendly_slug($this->item->form_name) . '.csv;',
+                    'Content-Disposition' => 'attachment; '.
+                        'filename='.\Nos\Orm_Behaviour_Virtualname::friendly_slug($this->item->form_name).'.csv;',
                     'Content-Transfer-Encoding' => 'binary',
                 ))->send(true);
 
@@ -349,7 +349,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                     }
                     $csv[] = $csv_row;
                 }
-                \Response::forge(\Format::forge($csv)->to_csv() . "\n")->send();
+                \Response::forge(\Format::forge($csv)->to_csv()."\n")->send();
 
                 if (count($answers) < $limit) {
                     break;

--- a/static/js/admin/insert_update.js
+++ b/static/js/admin/insert_update.js
@@ -923,7 +923,7 @@ define(
                     .find('span:first')
                     .html(mail.replace('\n', ', ', 'g'))
                     .end()
-                    .find('span:last')[mail ? 'hide' : 'show']();
+                    .find('span:last')[mail ? 'hide': 'show']();
             }).trigger('change');
 
             $submit_informations.on('click', function() {

--- a/static/js/admin/insert_update.js
+++ b/static/js/admin/insert_update.js
@@ -76,26 +76,27 @@ define(
                 var idRegex = /[^\[]+\[([0-9]+)\]\[([^\]]+)\]/;
 
 
-                $(this).find('input,textarea').each(function() {
-                    if (!$(this).attr('name')) {
+                $(this).find('input,textarea,select').each(function() {
+                    var $this = $(this);
+                    if (!$this.attr('name')) {
                         return;
                     }
 
                     // If the input name does not match the regex, put the value in the post as usual
                     // _csrf is handled here
-                    if ($(this).attr('name').indexOf(fieldPrefix) != 0) {
-                        ajaxData[$(this).attr('name')] = $(this).val();
+                    if ($this.attr('name').indexOf(fieldPrefix) != 0) {
+                        ajaxData[$this.attr('name')] = $this.val();
                         return;
                     }
 
-                    var fieldInfos = $(this).attr('name').match(idRegex);
+                    var fieldInfos = $this.attr('name').match(idRegex);
                     if (!fieldInfos.length || fieldInfos.length < 3) {
                         return;
                     }
 
                     var id = parseInt(fieldInfos[1]);
                     var fieldName = fieldInfos[2];
-                    var value = $(this).val();
+                    var value = $this.val();
                     if (!id || !fieldName) {
                         return;
                     }

--- a/static/js/admin/insert_update.js
+++ b/static/js/admin/insert_update.js
@@ -909,15 +909,15 @@ define(
                 $form_submit_label = $container.find('[name=form_submit_label]'),
                 $form_submit_email = $container.find('[name=form_submit_email]');
 
-            $form_captcha.on('change',function() {
+            $form_captcha.on('change', function() {
                 $submit_informations.find('.form_captcha')[$(this).is(':checked') ? 'show' : 'hide']();
             }).trigger('change');
 
-            $form_submit_label.on('change keyup',function() {
+            $form_submit_label.on('change keyup', function() {
                 $submit_informations.find('input:last').val($(this).val());
             }).trigger('change');
 
-            $form_submit_email.on('change keyup',function() {
+            $form_submit_email.on('change keyup', function() {
                 var mail = $.trim($(this).val());
                 $submit_informations.find('.form_submit_email')
                     .find('span:first')


### PR DESCRIPTION
Hi,

There is a little bottleneck in the application, when you add a big number of fields to one form, you could easily exceed PHP's POST parameters limit (max_input_vars: default 1000). 

To fix the problem i made a modification where instead of sendings fields as POST request, i serialized them in one post field in json, it can handle illimited number of forms until POST max size is reached.

There is still some performance issue, though, with a big number of fields, the ajax request takes ages to process, i will look into it later.
