### PR TITLE
Add attachment max size for mailing

### DIFF
--- a/config/noviusos_form.php
+++ b/config/noviusos_form.php
@@ -10,4 +10,5 @@
 
 return array(
     'add_replyto_to_first_email' => true,
+    'mail_attachments_max_size' => 8388608
 );


### PR DESCRIPTION
There is a bug which can cause memory exhaust when attaching big-ish files, because fuel's Email::attach create 3 times the files' content in memory at some point so with standard memory limit a ~30Mb file will make PHP throw an error.

What this PR do : 
- Add a configuration option setting the maximum size allowed for attachments (8Mb by default), if the sum of the form's attachments size are bigger than this option, no file will be sent in the mail at all, but they will still be processed as "answer attachment" and the mail will be sent with the answers.
- Remove all mailer activity whatsoever if there is no recipient, it used to initialize and attach files even if the mail wasn't send at the end.
