### PR TITLE
Bugfix search appdesk

### DIFF
--- a/config/controller/admin/answer/appdesk.config.php
+++ b/config/controller/admin/answer/appdesk.config.php
@@ -54,8 +54,8 @@ return array(
         function ($value, $query) {
             $query->related('fields', array('where' => array(
                 array('anfi_field_type', 'IN', array('text', 'textarea', 'checkbox', 'select', 'radio', 'email', 'number')),
-                array('anfi_value', 'LIKE', '%'.$value.'%'),
             )));
+            $query->where('fields.anfi_value', 'LIKE', '%'.$value.'%');
             return $query;
         }
     ),


### PR DESCRIPTION
There is a bug in the answers appdesk that make the search returns no result all the time.

This is caused by the search_text parameter not calling the where method on the query.
