### PR TITLE
Fixes the label for the file/select/date fields

### DIFF
--- a/classes/controller/front.ctrl.php
+++ b/classes/controller/front.ctrl.php
@@ -219,14 +219,6 @@ class Controller_Front extends Controller_Front_Application
 
                 if (in_array($field->field_type, array('text', 'textarea', 'select', 'email', 'number', 'date', 'file'))) {
 
-                    if (in_array($field->field_type, array('file', 'select', 'date'))) {
-                        // For the label
-                        $label = array(
-                            'callback' => 'html_tag',
-                            'args' => array('span', $label_attrs, $field->field_label),
-                        );
-                    }
-
                     if (in_array($field->field_type, array('text', 'email', 'number', 'date', 'file'))) {
                         $html_attrs['type'] = $field->field_type;
                         if (!empty($field->field_width)) {


### PR DESCRIPTION
Removes the custom `span` tag that replaced the `label` tag for the select/file/date fields, it makes no sense to do that...
