### PR TITLE
Fix the form fields being lost somehow

### DIFF
--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -46,9 +46,15 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
 
         // The field data is serialized in json (cf. Pull Request #15)
         $fields_post = \Input::post('fields', null);
-        $fields_data = array();
-        if ($fields_post !== null) {
-            $fields_data = json_decode($fields_post, true);
+        if (empty($fields_post)) {
+            throw new \Exception(__('Error: Your form seems to have no field.'));
+        }
+        $fields_data = json_decode($fields_post, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            logger(\Fuel::L_ERROR, 'Error: invalid fields format. JSON Error: '.json_last_error_msg());
+        }
+        if (empty($fields_data)) {
+            throw new \Exception(__('Your form must have at least one field.'));
         }
 
         foreach ($fields_data as $index => $field) {

--- a/lang/fr/common.lang.php
+++ b/lang/fr/common.lang.php
@@ -536,6 +536,12 @@ M.',
     #: views/email.view.php:31
     'Message sent by:' => 'Message envoyé par :',
 
+    #: classes/controller/admin/form.ctrl.php:50
+    'Error: Your form seems to have no field.' => 'Erreur: Il semble que votre formulaire ne comporte aucun champ.',
+
+    #: classes/controller/admin/form.ctrl.php:57
+    'Your form must have at least one field.' => 'Votre formulaire doit comporter au moins un champ.',
+
     #: classes/controller/admin/form.ctrl.php:187
     #: classes/controller/admin/form.ctrl.php:202
     'Page break' => 'Saut de page',

--- a/migrations/005_unique_index.php
+++ b/migrations/005_unique_index.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2011 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link http://www.novius-os.org
+ */
+
+namespace Nos\Form\Migrations;
+
+class Unique_Index extends \Nos\Migration
+{
+}

--- a/migrations/005_unique_index.sql
+++ b/migrations/005_unique_index.sql
@@ -1,0 +1,12 @@
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2011 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link http://www.novius-os.org
+ */
+
+ALTER TABLE `nos_form_answer_field`
+DROP INDEX `anfi_answer_id` ,
+ADD UNIQUE `anfi_answer_id`(`anfi_answer_id`, `anfi_field_id`);


### PR DESCRIPTION
This is an attempt to solve a recurrent bug where all the fields in a form has been removed (without the user asking to), while the form object, templates and answers still exists and refers to some missing fields.
I still didn't found the real bug source, but I'm quite sure it is related to some weird bug where the javascript doesn't send a valid `fields` json input. That case wasn't properly handled by the server, and an empty or invalid input could let the save action be executed on an empty `$fields_data` array.
Since there is no simple way to differenciate this bug from an intended empty form (= removing all fields), I also added an error message which prevents saving a form without any fields.

I also secured the database where the index wasn't unique.
