### PR TITLE
Listen for input and keyup events when observing inputs for condition…

### DIFF
--- a/static/js/condition.js
+++ b/static/js/condition.js
@@ -2,7 +2,7 @@ function init_form_condition(json) {
     $(document).ready(function() {
         check_option(json);
     });
-    $('[name^="'+json.inputname+'"]').change(function() {
+    $('[name^="'+json.inputname+'"]').on('keyup input change', function() {
         check_option(json);
     });
 


### PR DESCRIPTION
Adds the `keyup` and `input` events when observing a field for conditional display. Currently only the `change` event is observed, the problem is that for some inputs it's only triggered on blur (eg. email), which delays the display of the conditional field.

With these 2 new events, the conditional field is displayed instantly.
