### PR TITLE
Counts the form answers with a single COUNT query

### DIFF
--- a/classes/model/form.model.php
+++ b/classes/model/form.model.php
@@ -168,7 +168,7 @@ class Model_Form extends \Nos\Orm\Model
      */
     public function getAnswersCount()
     {
-        return $this->is_new() ? 0 : (int) \Nos\Form\Model_Answer::count(array(
+        return $this->is_new() ? 0 : (int) Model_Answer::count(array(
             'where' => array(
                 array('answer_form_id' => $this->form_id),
             ),

--- a/classes/model/form.model.php
+++ b/classes/model/form.model.php
@@ -160,4 +160,18 @@ class Model_Form extends \Nos\Orm\Model
 
         \Nos\Attachment::deleteAlias('form/'.$this->_form_id_for_delete);
     }
+
+    /**
+     * Gets the answers count
+     *
+     * @return int
+     */
+    public function getAnswersCount()
+    {
+        return $this->is_new() ? 0 : (int) \Nos\Form\Model_Answer::count(array(
+            'where' => array(
+                array('answer_form_id' => $this->form_id),
+            ),
+        ));
+    }
 }

--- a/config/common/form.config.php
+++ b/config/common/form.config.php
@@ -149,9 +149,7 @@ return array(
             },
             'disabled' => array(
                 'check_empty' => function ($item) {
-                    if ($item->is_new() || !\Nos\Form\Model_Answer::count(array(
-                        'where' => array(array('answer_form_id' => $item->form_id)),
-                    ))) {
+                    if ($item->is_new() || !$item->getAnswersCount()) {
                         return __('There is no answers yet.');
                     }
                 },

--- a/config/common/form.config.php
+++ b/config/common/form.config.php
@@ -127,9 +127,7 @@ return array(
             ),
             'disabled' => array(
                 'check_empty' => function ($item) {
-                    if ($item->is_new() || !\Nos\Form\Model_Answer::count(array(
-                        'where' => array(array('answer_form_id' => $item->form_id)),
-                    ))) {
+                    if ($item->is_new() || !$item->getAnswersCount()) {
                         return __('There is no answers yet.');
                     }
                 }

--- a/config/common/form.config.php
+++ b/config/common/form.config.php
@@ -37,9 +37,7 @@ return array(
                 ),
             ),
             'value' => function ($item) {
-                return $item->is_new() ? 0 : \Nos\Form\Model_Answer::count(array(
-                        'where' => array(array('answer_form_id' => $item->form_id)),
-                    ));
+                return $item->getAnswersCount();
             },
             'sorting_callback' => function (&$query, $sortDirection) {
                 $query->_join_relation('answers', $join);

--- a/views/admin/layout_fields.view.php
+++ b/views/admin/layout_fields.view.php
@@ -14,7 +14,8 @@ Nos\I18n::current_dictionary(array('noviusos_form::common', 'nos::common'));
 <link rel="stylesheet" href="<?= Uri::base(false) ?>static/apps/noviusos_form/css/admin.css" />
 
 <?php
-if (!$item->is_new() && count($item->answers) > 0) {
+
+if (!$item->is_new() && $item->getAnswersCount() > 0) {
     echo \View::forge('noviusos_form::admin/warning_answers_collected', $view_params, false);
 }
 ?>

--- a/views/admin/popup_delete.view.php
+++ b/views/admin/popup_delete.view.php
@@ -8,10 +8,10 @@
  * @link http://www.novius-os.org
  */
 
-
 Nos\I18n::current_dictionary(array('noviusos_form::common', 'nos::common'));
 
-$answer_count = count($item->answers);
+$answer_count = $item->getAnswersCount();
+
 ?>
 <input type="hidden" name="id" value="<?= $item->{$crud['pk']} ?>" />
 <div id="<?= $uniqid = uniqid('id_') ?>" class="fieldset standalone">


### PR DESCRIPTION
Counts the form answers with a single COUNT query instead of counting the related items (which requires all the related items to be loaded in memory in order to count them...).

This PR will prevent crash on forms that have a lot of answers (1000+).
