### PR TITLE
check requirement number field

### DIFF
--- a/classes/driver/field/input/number.php
+++ b/classes/driver/field/input/number.php
@@ -57,6 +57,7 @@ class Driver_Field_Input_Number extends Driver_Field_Input
         if (!is_int($value) && !ctype_digit($value)) {
             return null;
         }
+
         return (int) $value;
     }
 }

--- a/classes/driver/field/input/number.php
+++ b/classes/driver/field/input/number.php
@@ -20,6 +20,22 @@ class Driver_Field_Input_Number extends Driver_Field_Input
     }
 
     /**
+     * checks requirement state
+     *
+     * @param $inputValue
+     * @param null $formData
+     * @return bool
+     */
+    public function checkRequirement($inputValue, $formData = null)
+    {
+        if (!$this->isMandatory()) {
+            return true;
+        }
+
+        return is_int($inputValue) && !empty($inputValue);
+    }
+
+    /**
      * Gets the input type
      *
      * @return string

--- a/classes/driver/field/input/number.php
+++ b/classes/driver/field/input/number.php
@@ -32,7 +32,7 @@ class Driver_Field_Input_Number extends Driver_Field_Input
             return true;
         }
 
-        return is_int($inputValue) && !empty($inputValue);
+        return is_int($inputValue);
     }
 
     /**
@@ -47,12 +47,16 @@ class Driver_Field_Input_Number extends Driver_Field_Input
 
     /**
      * Sanitizes the value
+     * This method is called in front-office (with string) input value and in back-office (with int)
      *
      * @param $value
      * @return int
      */
     public function sanitizeValue($value)
     {
+        if (!is_int($value) && !ctype_digit($value)) {
+            return null;
+        }
         return (int) $value;
     }
 }


### PR DESCRIPTION
There was no requirerment for number field. As default, it was the abstract method it was used :
`return is_string($inputValue) && $inputValue !== '';`