### PR TITLE
Fixes a browser related bug when first choice is an empty line

### DIFF
--- a/config/controller/admin/form.config.php
+++ b/config/controller/admin/form.config.php
@@ -286,7 +286,15 @@ return array(
                     'value' => '',
                 ),
                 'populate' => function ($item) {
-                    return is_array($item->choices) ? implode(PHP_EOL, $item->choices) : $item->choices;
+                    $choices = is_array($item->choices) ? implode(PHP_EOL, $item->choices) : $item->choices;
+
+                    // If a text node begins with white space (space, new line) it will be ignored by some HTML parsers :
+                    // * https://bugs.chromium.org/p/chromium/issues/detail?id=60484
+                    // * https://bugs.webkit.org/show_bug.cgi?id=56434
+                    // To fix this we have to encode the first empty line as an HTML entity
+                    $choices = preg_replace('`^\n`', '&#13;', $choices);
+
+                    return $choices;
                 },
             ),
             'field_mandatory' => array(


### PR DESCRIPTION
If you add an empty line as first choice and then save the form, an empty option will be available when displaying the form in front-office. If you reload the CRUD, the empty line won't appear anymore, and if you save the form again, it won't be available anymore.

This is related to the way browsers handle the content of a `textarea` field. If a text node begins with white space (space, new line) it will be ignored by some HTML parsers:
* https://bugs.chromium.org/p/chromium/issues/detail?id=60484
* https://bugs.webkit.org/show_bug.cgi?id=56434

Although it seems to have been corrected for a while, it has reappeared.

The fix consists of replacing the first empty line by the corresponding HTML entity, so it won't be lost.