### PR TITLE
PHP_EOL constants + eventual bugifx with illegal spaces

### DIFF
--- a/classes/controller/admin/form.ctrl.php
+++ b/classes/controller/admin/form.ctrl.php
@@ -40,7 +40,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
      */
     public function before_save($item, $data)
     {
-        $emails = explode("\n", $item->form_submit_email);
+        $emails = explode(PHP_EOL, $item->form_submit_email);
         $item->form_submit_email = '';
         foreach ($emails as $email) {
             $email = trim($email);
@@ -48,7 +48,7 @@ class Controller_Admin_Form extends \Nos\Controller_Admin_Crud
                 continue;
             }
             if (filter_var(trim($email), FILTER_VALIDATE_EMAIL)) {
-                $item->form_submit_email .= $email."\n";
+                $item->form_submit_email .= $email.PHP_EOL;
             } else {
                 throw new \Exception('An email which receive answers is not valid.');
             }

--- a/classes/driver/field/recipient/select.php
+++ b/classes/driver/field/recipient/select.php
@@ -17,10 +17,10 @@ class Driver_Field_Recipient_Select extends Driver_Field_Select
     {
         // Gets the field value
         $value = $this->sanitizeValue($inputValue);
-        $label = $this->getValueChoiceLabel($value);
+        $label = trim($this->getValueChoiceLabel($value));
         if (!empty($label) && filter_var($label, FILTER_VALIDATE_EMAIL)) {
             // Add the value to the recipient list
-            $form->form_submit_email .= $label."\n";
+            $form->form_submit_email .= $label.PHP_EOL;
         }
     }
 }

--- a/classes/service/answer.php
+++ b/classes/service/answer.php
@@ -110,7 +110,7 @@ class Service_Answer
 
         // Gets the recipient list
         $config = \Config::load('noviusos_form::config', true);
-        $recipients = array_filter(explode("\n", $form->form_submit_email), function ($var) {
+        $recipients = array_filter(explode(PHP_EOL, $form->form_submit_email), function ($var) {
             $var = trim($var);
 
             return !empty($var) && filter_var($var, FILTER_VALIDATE_EMAIL);


### PR DESCRIPTION
Avoids a possible bug when unwanted spaces are presents in recipent email value.
Example : 
`Subject 1= alert@mydomain.fr`
In this case, with this feature the mail will be sent despite unwanted space.

I've also replaced `"\n"` by `PHP_EOL` constant.
