### PR TITLE
fix date on answers crud

### DIFF
--- a/classes/driver/field/input/date.php
+++ b/classes/driver/field/input/date.php
@@ -32,7 +32,7 @@ class Driver_Field_Input_Date extends Driver_Field_Input
         $value = $this->sanitizeValue($answerField->value);
         if (!empty($value)) {
             try {
-                return \Date::create_from_string($answerField->value, 'mysql_date')->wijmoFormat();
+                return \Date::create_from_string($answerField->value, 'mysql_date')->format('%d/%m/%Y');
             } catch (\Exception $e) {
             }
         }


### PR DESCRIPTION
On answer crud, wijmoFormat printed /Date('mytimestamp')/ and not a clear human format date.